### PR TITLE
add support for custom templates

### DIFF
--- a/rsyslog/init.sls
+++ b/rsyslog/init.sls
@@ -25,8 +25,13 @@ config_{{ rsyslog.config }}:
 {% for filename in salt['pillar.get']('rsyslog:custom', {}) %}
 rsyslog_custom_{{filename}}:
   file.managed:
+    - source: salt://rsyslog/files/{{ filename }}
+    {% if filename.endswith('.jinja') %}
+    - template: jinja
+    - name: {{ rsyslog.custom_config_path }}/{{ filename|replace(".jinja", "") }}
+    {% else %}
     - name: {{ rsyslog.custom_config_path }}/{{ filename }}
-    - source: salt://rsyslog/{{ filename }}
+    {% endif %}
     - watch_in: 
       - service: {{ rsyslog.service }}
 {% endfor %}

--- a/rsyslog/init.sls
+++ b/rsyslog/init.sls
@@ -25,12 +25,10 @@ config_{{ rsyslog.config }}:
 {% for filename in salt['pillar.get']('rsyslog:custom', {}) %}
 rsyslog_custom_{{filename}}:
   file.managed:
+    - name: {{ rsyslog.custom_config_path }}/{{ filename|replace(".jinja", "") }}
     - source: salt://rsyslog/files/{{ filename }}
     {% if filename.endswith('.jinja') %}
     - template: jinja
-    - name: {{ rsyslog.custom_config_path }}/{{ filename|replace(".jinja", "") }}
-    {% else %}
-    - name: {{ rsyslog.custom_config_path }}/{{ filename }}
     {% endif %}
     - watch_in: 
       - service: {{ rsyslog.service }}


### PR DESCRIPTION
Hi,

this patch introduces support for custom configs as templates as well. If a file ends with ".jinja" templating will be enabled.

The second small change is a change in the source path: The more common way of serving additional files is via some files/ subdirectory, so I changed from "rsyslog/"  to "rsyslog/files/".
As soo as you start writing addional local sls files for rsyslog in /srv/salt/rsyslog this change becomes more important to keep everything tidy. I hope you agree.
