### PR TITLE
Added config and custom_config_path variables for RedHat systems

### DIFF
--- a/rsyslog/map.jinja
+++ b/rsyslog/map.jinja
@@ -8,5 +8,7 @@
     'RedHat': {
         'package': 'rsyslog',
         'service': 'rsyslog',
+        'config': '/etc/rsyslog.conf',
+        'custom_config_path': '/etc/rsyslog.d',
     },
 }, merge=salt['pillar.get']('rsyslog:lookup')) %}


### PR DESCRIPTION
On a base Centos 6.5 install I was getting the following error:

==> frontend1:     Data failed to compile:
==> frontend1: ----------
==> frontend1:     Rendering SLS 'base:rsyslog' failed: Jinja variable 'dict object' has no attribute 'config'

It was due to missing variables in map.jinja.