### PR TITLE
add ability to pass custom template for /etc/rsyslog.conf

### DIFF
--- a/rsyslog/defaults.yaml
+++ b/rsyslog/defaults.yaml
@@ -11,3 +11,4 @@ rsyslog:
   exclusive: True
   stoplist:
     - syslogd
+  custom_config_template: salt://rsyslog/templates/rsyslog.conf.jinja

--- a/rsyslog/init.sls
+++ b/rsyslog/init.sls
@@ -17,7 +17,7 @@ rsyslog:
   file.managed:
     - name: {{ rsyslog.config }}
     - template: jinja
-    - source: salt://rsyslog/templates/rsyslog.conf.jinja
+    - source: {{ rsyslog.custom_config_template }}
     - context:
       config: {{ salt['pillar.get']('rsyslog', {}) }}
   service.running:


### PR DESCRIPTION
due to the complexity of the rsyslog.conf and the different syntax in
the newest version, this commit provides the ability to pass a custom
template for this config file