### PR TITLE
FreeBSD support and exclusive logger feature

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,11 @@ Configures and starts rsyslog service. Currently the log file schema is based on
 control if rsyslog should listen for tcp / udp connections. Further ikml logging (kernel) logging can be disabled, e.g. for lxc containers.
 It supports both a client only (sending all logs to another machine) and a server side (receiving logs from mulitple other machines).
 
+It works on Redhat, Debian, FreeBSD, Suse and Arch OS families.
+
+In situations where there's already a default logger installed (e.g. a FreeBSD jail), an option exists to declare that rsyslog is the exclusive system logger.
+This provides a facility to add other loggers to a stoplist which helps, for example, to ensure that port 514 UDP is free for rsylog to use.
+
 .. note::
 
    Contributions are welcome.

--- a/rsyslog/defaults.yaml
+++ b/rsyslog/defaults.yaml
@@ -8,3 +8,6 @@ rsyslog:
   config: /etc/rsyslog.conf
   workdirectory: /var/spool/rsyslog
   custom_config_path: /etc/rsyslog.d
+  exclusive: True
+  stoplist:
+    - syslogd

--- a/rsyslog/init.sls
+++ b/rsyslog/init.sls
@@ -1,5 +1,16 @@
 {% from "rsyslog/map.jinja" import rsyslog with context %}
 
+{% if rsyslog.exclusive %}
+{% for logger in rsyslog.stoplist %}
+stoplogger_{{logger}}:
+  service.dead:
+    - enable: False
+    - name: {{ logger }}
+    - require_in:
+      - service: {{ rsyslog.service }}
+{% endfor %}
+{% endif %}
+
 rsyslog:
   pkg.installed:
     - name: {{ rsyslog.package }}

--- a/rsyslog/init.sls
+++ b/rsyslog/init.sls
@@ -38,6 +38,10 @@ rsyslog_custom_{{basename}}:
     {% if filename.endswith('.jinja') %}
     - template: jinja
     {% endif %}
+    - user: {{ rsyslog.runuser }}
+    - group: {{ rsyslog.rungroup }}
+    - dirmode: 755
+    - makedirs: True
     - watch_in:
       - service: {{ rsyslog.service }}
 {% endfor %}

--- a/rsyslog/map.jinja
+++ b/rsyslog/map.jinja
@@ -13,6 +13,12 @@ that differ from whats in defaults.yaml
     'RedHat': {
       'workdirectory': '/var/lib/rsyslog',
     },
+    'FreeBSD': {
+        'service': 'rsyslogd',
+        'config': '/usr/local/etc/rsyslog.conf',
+        'custom_config_path': '/usr/local/etc/rsyslog.d',
+        'rungroup': 'wheel',
+    },
     'Arch': {},
     'Suse': {},
   }, grain='os_family', merge=salt['pillar.get']('rsyslog:lookup')) 


### PR DESCRIPTION
Hi,

I've made some mods to get rsyslog working on FreeBSD. Specifically, I wanted a centralised rsyslog service running inside a FreeBSD jail on FreeNAS.

I've also added a feature that allows for rsyslog to be the exclusive logger on a system.
In this mode, you can specify a list of baked-in loggers that you explicitly want stopped before the rsyslog service starts.
Comments welcome.

Cheers,
Cam.