### PR TITLE
default: /dev/console, not xconsole

### DIFF
--- a/rsyslog/files/50-default.conf
+++ b/rsyslog/files/50-default.conf
@@ -65,4 +65,4 @@ news.notice     -/var/log/news/news.notice
 daemon.*;mail.*;\
   news.err;\
   *.=debug;*.=info;\
-  *.=notice;*.=warn |/dev/xconsole
+  *.=notice;*.=warn |/dev/console


### PR DESCRIPTION
Not sure where xconsole was a default.
Not the default on debian I installed...