### PR TITLE
fix pillar rendering

### DIFF
--- a/rsyslog/init.sls
+++ b/rsyslog/init.sls
@@ -19,7 +19,7 @@ rsyslog:
     - template: jinja
     - source: {{ rsyslog.custom_config_template }}
     - context:
-      config: {{ salt['pillar.get']('rsyslog', {}) }}
+      config: {{ rsyslog|json }}
   service.running:
     - enable: True
     - name: {{ rsyslog.service }}

--- a/rsyslog/init.sls
+++ b/rsyslog/init.sls
@@ -19,7 +19,7 @@ rsyslog:
     - template: jinja
     - source: {{ rsyslog.custom_config_template }}
     - context:
-      config: {{ rsyslog|json }}
+        config: {{ rsyslog|json }}
   service.running:
     - enable: True
     - name: {{ rsyslog.service }}


### PR DESCRIPTION
This PR fixes rendering of pillar data.

I noticed an issue after upgrading to Salt 2019, Pillar information was not being passed correctly.
For example when the following pillar was applied:
#### Pillar
```YAML
rsyslog:
  protocol: udp
  listenudp: True
```

This information would not get passed into the template correctly.  (Uses default values)
```YAML
          ID: rsyslog
    Function: file.managed
        Name: /etc/rsyslog.conf
      Result: True
     Comment: File /etc/rsyslog.conf is in the correct state
     Started: 22:01:33.588812
    Duration: 35.673 ms
     Changes:   
```
After updating to
`{{ rsyslog|json }}`
```YAML
     Changes:   
              ----------
              diff:
                  --- 
                  +++ 
                  @@ -15,7 +15,9 @@
                   
                   #$ModLoad immark  # provides --MARK-- message capability
                   
                  -
                  +# provides UDP syslog reception
                  +$ModLoad imudp
                  +$UDPServerRun 514
```

The template populated correctly.

Verified on:
- [x] Ubuntu 18.04
- [x] CentOS 7